### PR TITLE
docs(README.md): merge README.md and CHANGELOG.md when publishing to PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,17 +174,16 @@ uv build
 - [mise] - The official mise project
 - [mise-cookbooks] - Collection of mise cookbooks
 
-## Changelog :memo:
-
-For a detailed list of changes, please refer to the [CHANGELOG](./CHANGELOG.md).
-
 ## License :scroll:
 
 This project is licensed under the [MIT License](https://opensource.org/license/MIT).
 
 <!-- Refs -->
-
 [mise-cookbooks]: https://github.com/hasansezertasan/mise-cookbooks
 [mise]: https://github.com/jdx/mise
 [author]: https://github.com/hasansezertasan
 [micoo]: https://github.com/hasansezertasan/micoo
+
+## Changelog :memo:
+
+For a detailed list of changes, please refer to the [CHANGELOG](./CHANGELOG.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,14 @@ replacement = "[#\\1](https://github.com/hasansezertasan/micoo/issues/\\1)"
 pattern = '\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]'
 replacement = '**\1**:'
 
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '\nFor a detailed list of changes, please refer to the \[CHANGELOG\]\(https:\/\/github\.com\/[^\/]+\/[^\/]+\/tree\/[^\/]+\/\.\/CHANGELOG\.md\)\.'
+replacement = ''
+
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+path = "CHANGELOG.md"
+
 
 [tool.commitizen]
 major_version_zero = true


### PR DESCRIPTION
## Summary by Sourcery

Integrate CHANGELOG.md into the PyPI package long description by configuring Hatch Fancy PyPI Readme hooks and update the README to relocate the Changelog section.

Enhancements:
- Configure hatch.metadata.hooks.fancy-pypi-readme in pyproject.toml to include CHANGELOG.md as a fragment in the PyPI description
- Add a substitution rule to remove the placeholder CHANGELOG link when publishing to PyPI

Build:
- Add substitutions and fragments under tool.hatch.metadata.hooks.fancy-pypi-readme in pyproject.toml to merge the changelog

Documentation:
- Move the Changelog section in README.md to the end of the document