### PR TITLE
Revert "Release 0.2.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update
-
-## [0.2.0] - 2025-07-27
-
-### Changed
-
-- Git-cliff integration by @hasansezertasan in [#6](https://github.com/hasansezertasan/micoo/pull/6)
 - Implement dynamic arguments and pin python version to 3.9 by @hasansezertasan in [#4](https://github.com/hasansezertasan/micoo/pull/4)
 - Generate release notes and discussions on gh-release, adjust permissions, bump setup-uv version by @hasansezertasan in [#3](https://github.com/hasansezertasan/micoo/pull/3)
 
@@ -41,7 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - @hasansezertasan made their first contribution
 
 <!-- refs -->
-[unreleased]: https://github.com/hasansezertasan/micoo/compare/0.2.0..HEAD
-[0.2.0]: https://github.com/hasansezertasan/micoo/compare/0.1.0..0.2.0
+[unreleased]: https://github.com/hasansezertasan/micoo/compare/0.1.0..HEAD
 
 <!-- changelog-end -->


### PR DESCRIPTION
Reverts hasansezertasan/micoo#7

## Summary by Sourcery

Revert the 0.2.0 release entries from the changelog and restore the unreleased comparison to version 0.1.0

Chores:
- Remove the 0.2.0 section and its entries from CHANGELOG.md
- Update the unreleased comparison link to reference 0.1.0 as the base