### PR TITLE
ci(release-please): set changelog-type to github

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,8 @@
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "changelog-type": "github"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Set changelog-type to github in the release-please configuration