### PR TITLE
feat(command): implemented a new command to display the path to the micoo log file

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,22 +62,24 @@ Here is the output of the `micoo --help` command:
 
 ```sh
  Usage: micoo [OPTIONS] COMMAND [ARGS]...
-╭─ Options ─────────────────────────────────────────────────────────────────────────────╮
-│ --install-completion          Install completion for the current shell.               │
-│ --show-completion             Show completion for the current shell, to copy it or    │
-│                               customize the installation.                             │
-│ --help                        Show this message and exit.                             │
-╰───────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ────────────────────────────────────────────────────────────────────────────╮
-│ update    Clone or fetch the `mise-cookbooks` repository.                             │
-│ list      List the available mise cookbooks.                                          │
-│ search    Search for a mise cookbook.                                                 │
-│ dump      Dump a mise cookbook.                                                       │
-│ root      Show the path to the micoo boilerplates directory.                          │
-│ remote    Show the URL to the remote repository.                                      │
-│ version   Show the current version number of micoo.                                   │
-│ info      Display information about the micoo application.                            │
-╰───────────────────────────────────────────────────────────────────────────────────────╯
+
+╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────╮
+│ --install-completion          Install completion for the current shell.                            │
+│ --show-completion             Show completion for the current shell, to copy it or customize the   │
+│                               installation.                                                        │
+│ --help                        Show this message and exit.                                          │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ─────────────────────────────────────────────────────────────────────────────────────────╮
+│ update    Clone or fetch the `mise-cookbooks` repository.                                          │
+│ list      List the available mise cookbooks.                                                       │
+│ search    Search for a mise cookbook.                                                              │
+│ dump      Dump a mise cookbook.                                                                    │
+│ root      Show the path to the micoo boilerplates directory.                                       │
+│ log       Show the path to the micoo log file.                                                     │
+│ remote    Show the URL to the remote repository.                                                   │
+│ version   Show the current version number of micoo.                                                │
+│ info      Display information about the micoo application.                                         │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## Usage :hammer_and_wrench:
@@ -109,16 +111,22 @@ Dump a specific cookbook to a `mise.toml` file:
 micoo dump python > mise.toml
 ```
 
-Open the [mise-cookbooks] repository in the browser:
+Open the [mise-cookbooks] repository in the default application:
 
 ```sh
 open $(micoo remote)
 ```
 
-Open the cloned repository in the file manager:
+Open the cloned repository in the default application:
 
 ```sh
 open $(micoo root)
+```
+
+Open the log file in the default application:
+
+```sh
+open $(micoo log)
 ```
 
 Show the current version of `micoo`:

--- a/src/micoo/main.py
+++ b/src/micoo/main.py
@@ -12,6 +12,7 @@ from git import GitCommandError, Repo
 from micoo.config import (
     cookbooks_repository_url,
     file_extension,
+    log_file_path,
     micoo_repository_url,
     repository_path,
 )
@@ -265,6 +266,25 @@ def root() -> None:
 
 
 @app.command()
+def log() -> None:
+    """Show the path to the micoo log file.
+
+    Show the log file location:
+        micoo log
+
+    Example output:
+        /Users/hasansezertasan/Library/Logs/micoo/micoo.log
+
+    Open the log file in a file manager:
+        open $(micoo log)
+
+    """
+    logger.info("Command `log` called.")
+    typer.echo(log_file_path)
+    logger.info("Log file displayed successfully.")
+
+
+@app.command()
 def remote() -> None:
     """Show the URL to the remote repository.
 
@@ -290,7 +310,7 @@ def show_version() -> None:
         micoo version
 
     Example output:
-        0.1.dev0+d20250726
+        0.4.0
     """
     logger.info("Command `version` called.")
     typer.echo(version("micoo"))
@@ -305,11 +325,12 @@ def info() -> None:
         micoo info
 
     Example output:
-        Application Version: 0.1.dev0+d20250726
-        Python Version: 3.8.20 (CPython)
+        Application Version: 0.4.0
+        Python Version: 3.9.23 (CPython)
         Platform: Darwin
         Repository Path: /Users/hasansezertasan/Library/Caches/micoo/mise-cookbooks
         Repository URL: https://github.com/hasansezertasan/mise-cookbooks/tree/81747c2e983fa1278005c8cb8b0e311a7726923a
+        Log File: /Users/hasansezertasan/Library/Logs/micoo/micoo.log
     """
     logger.info("Command `info` called.")
     python_version = platform.python_version()
@@ -323,4 +344,5 @@ def info() -> None:
         repo = Repo(repository_path)
         url = f"{cookbooks_repository_url}/tree/{repo.head.commit.hexsha}"
     typer.echo(f"Repository URL: {url}")
+    typer.echo(f"Log File: {log_file_path}")
     logger.info("Application information displayed successfully.")


### PR DESCRIPTION
## Summary by Sourcery

Implement a new `log` command to reveal the path to the micoo log file and update the CLI help, usage examples, and info output accordingly.

New Features:
- Add `log` command to display the path to the micoo log file

Enhancements:
- Include log file path in the output of the `info` command

Documentation:
- Update README: add `log` command to the CLI help and usage examples
- Bump example application and Python versions in help output to 0.4.0 and 3.9.23