### PR TITLE
fix(check-pr-title): update sticky-pull-request-comment action to version 2.9.0

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,3 +1,4 @@
+---
 name: Lint PR
 on:
   pull_request_target:
@@ -14,7 +15,7 @@ jobs:
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@v2.9.0
         # When the previous steps fails, the workflow would stop. By adding this
         # condition you can continue the execution with the populated error message.
         if: always() && (steps.lint_pr_title.outputs.error_message != null)


### PR DESCRIPTION
## Summary by Sourcery

Upgrade the sticky-pull-request-comment GitHub Action and adjust the workflow file

Enhancements:
- Add YAML document start delimiter to the check-pr-title workflow file

CI:
- Bump marocchino/sticky-pull-request-comment action to v2.9.0 in the check-pr-title workflow