### PR TITLE
chore(ci): set timeout for CI jobs to 10 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     name: Run Tests on ${{ matrix.os }}
+    timeout-minutes: 10
     steps:
       - name: System Info
         shell: bash


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Set a 10-minute timeout for all CI workflow jobs