### PR TITLE
refactor(pre-commit): extend pre-commit excludes and customize pr titles

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,14 +3,27 @@
 # See https://pre-commit.com/hooks.html for more hooks
 exclude: |
   (?x)^(
-
     # Ignore `.devcontainer/devcontainer.json`
     |\.devcontainer/devcontainer\.json$
 
     # Ignore `.vscode/launch.json`
     |\.vscode/launch\.json$
 
+    # Ignore VCS and Python build/virtualenv directories
+    |\.git
+    |\.hg
+    |\.mypy_cache
+    |\.nox
+    |\.tox
+    |\.venv
+    |_build
+    |buck-out
+    |build
+    |dist
+    |alembic
   )$
+ci:
+  autoupdate_commit_msg: "chore(pre-commit): autoupdate"
 repos:
   # https://github.com/pre-commit/pre-commit-hooks#pre-commit-hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
## Summary by Sourcery

Extend pre-commit configuration to ignore common VCS and Python build directories and customize autoupdate commit messages

Enhancements:
- Ignore Git, Mercurial, virtualenv, build output, and caching directories in pre-commit excludes

CI:
- Set autoupdate_commit_msg to "chore(pre-commit): autoupdate" for consistent commit titles