### PR TITLE
ci: add Codecov coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Run Tests on ${{ matrix.os }}
     timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: System Info
         shell: bash
@@ -65,5 +68,4 @@ jobs:
           files: ./coverage.xml
           flags: ${{ matrix.os }}
           fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,12 @@ jobs:
         run: echo "Cache was restored"
       - name: Run the tests
         run: uv run --locked tox run
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v6
+        with:
+          files: ./coverage.xml
+          flags: ${{ matrix.os }}
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![License - MIT](https://img.shields.io/github/license/hasansezertasan/micoo.svg)](https://opensource.org/licenses/MIT)
 [![Latest Commit](https://img.shields.io/github/last-commit/hasansezertasan/micoo)][micoo]
 
-[![Codecov](https://codecov.io/gh/hasansezertasan/micoo/branch/main/graph/badge.svg)](https://codecov.io/gh/hasansezertasan/micoo)
+[![codecov](https://codecov.io/gh/hasansezertasan/micoo/graph/badge.svg?token=z8EzL0t2cT)](https://codecov.io/gh/hasansezertasan/micoo)
 
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 [![linting - Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)

--- a/README.md
+++ b/README.md
@@ -8,11 +8,7 @@
 [![License - MIT](https://img.shields.io/github/license/hasansezertasan/micoo.svg)](https://opensource.org/licenses/MIT)
 [![Latest Commit](https://img.shields.io/github/last-commit/hasansezertasan/micoo)][micoo]
 
-<!-- [![Coverage](https://codecov.io/gh/hasansezertasan/micoo/graph/badge.svg?token=XXXXXXXXXXX)](https://codecov.io/gh/hasansezertasan/micoo) -->
-
-<!-- [![Coverage](https://img.shields.io/codecov/c/github/hasansezertasan/micoo)](https://codecov.io/gh/hasansezertasan/micoo) -->
-
-<!-- [![Coverage](https://codecov.io/gh/hasansezertasan/micoo/branch/main/graph/badge.svg)](https://codecov.io/gh/hasansezertasan/micoo) -->
+[![Codecov](https://codecov.io/gh/hasansezertasan/micoo/branch/main/graph/badge.svg)](https://codecov.io/gh/hasansezertasan/micoo)
 
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 [![linting - Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,23 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+
+flag_management:
+  default_rules:
+    carryforward: true
+
+ignore:
+  - "tests/**"
+  - "src/micoo/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,7 +261,7 @@ max-complexity = 5
 strict-imports = false
 
 [tool.tox]
-env_list = ["style", "run", "3.14"]
+env_list = ["style", "run", "3.14", "cov"]
 requires = ["tox>=4"]
 
 [tool.tox.env_run_base]
@@ -277,9 +277,6 @@ commands = [
     { replace = "posargs", default = [
     ], extend = true },
   ],
-  ["coverage", "combine"],
-  ["coverage", "xml"],
-  ["coverage", "report"],
 ]
 constrain_package_deps = true
 dependency_groups = ["test"]
@@ -316,6 +313,19 @@ description = "Run Linters and Formatters"
 [tool.tox.env.run]
 commands = [["micoo", "version", { replace = "posargs", extend = true }]]
 description = "Run the application"
+
+[tool.tox.env.cov]
+base_python = ["3.14"]
+commands = [
+  ["coverage", "combine"],
+  ["coverage", "xml"],
+  ["coverage", "report"],
+]
+dependency_groups = ["test"]
+depends = ["3.14"]
+description = "Combine coverage data and emit XML/report"
+runner = "uv-venv-runner"
+skip_install = true
 
 [tool.ty.src]
 include = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,6 +267,9 @@ requires = ["tox>=4"]
 [tool.tox.env_run_base]
 commands = [
   [
+    "coverage",
+    "run",
+    "-m",
     "pytest",
     "-v",
     "--tb=short",
@@ -274,6 +277,9 @@ commands = [
     { replace = "posargs", default = [
     ], extend = true },
   ],
+  ["coverage", "combine"],
+  ["coverage", "xml"],
+  ["coverage", "report"],
 ]
 constrain_package_deps = true
 dependency_groups = ["test"]


### PR DESCRIPTION
## Summary
- Wrap pytest in `coverage run` via tox `env_run_base`; chain `combine`/`xml`/`report`.
- CI uploads `coverage.xml` to Codecov per matrix OS via `codecov/codecov-action@v6`.
- Add `codecov.yml` (auto target, 1% threshold, per-flag carryforward, ignore tests + `_version.py`).
- Enable Codecov badge in README; drop commented variants.

Mirrors setup from [starlette-admin-fields](https://github.com/hasansezertasan/starlette-admin-fields/) and [not-just-a-todo-app](https://github.com/hasansezertasan/not-just-a-todo-app).

## Test plan
- [x] `tox run -e 3.14` locally — passes, generates `coverage.xml`, reports 78% total
- [ ] CI green on all three OS matrix legs
- [ ] Codecov upload visible on PR
- [ ] Add `CODECOV_TOKEN` repo secret (if not already set)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR integrates Codecov coverage reporting into the CI pipeline. It wraps pytest execution with `coverage run` in tox configuration, uploads generated `coverage.xml` files to Codecov from all OS matrix jobs in the CI workflow, adds a `codecov.yml` configuration file with auto-target and 1% threshold settings, and enables the Codecov badge in the README while removing commented-out badge variants.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `codecov.yml` |
| 2 | `pyproject.toml` |
| 3 | `.github/workflows/ci.yml` |
| 4 | `README.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->