### PR TITLE
fix(deps): bump pytest-dependency to >=0.6.1 for Windows build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ lint = [
 test = [
   "coverage-enable-subprocess==1.0",
   "coverage[toml]~=7.4",
-  "pytest-dependency>=0.6.0",
+  "pytest-dependency>=0.6.1",
   "pytest-mock~=3.12",
   "pytest-rerunfailures~=16.1",
   "pytest-xdist[psutil]~=3.5",

--- a/uv.lock
+++ b/uv.lock
@@ -339,7 +339,7 @@ dev = [
     { name = "pyrefly", specifier = "==1.0.0" },
     { name = "pyright", specifier = ">=1.1.403" },
     { name = "pytest", specifier = "~=9.0" },
-    { name = "pytest-dependency", specifier = ">=0.6.0" },
+    { name = "pytest-dependency", specifier = ">=0.6.1" },
     { name = "pytest-mock", specifier = "~=3.12" },
     { name = "pytest-rerunfailures", specifier = "~=16.1" },
     { name = "pytest-xdist", extras = ["psutil"], specifier = "~=3.5" },
@@ -371,7 +371,7 @@ test = [
     { name = "coverage", extras = ["toml"], specifier = "~=7.4" },
     { name = "coverage-enable-subprocess", specifier = "==1.0" },
     { name = "pytest", specifier = "~=9.0" },
-    { name = "pytest-dependency", specifier = ">=0.6.0" },
+    { name = "pytest-dependency", specifier = ">=0.6.1" },
     { name = "pytest-mock", specifier = "~=3.12" },
     { name = "pytest-rerunfailures", specifier = "~=16.1" },
     { name = "pytest-xdist", extras = ["psutil"], specifier = "~=3.5" },
@@ -646,13 +646,13 @@ wheels = [
 
 [[package]]
 name = "pytest-dependency"
-version = "0.6.0"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
     { name = "setuptools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/3b/317cc04e77d707d338540ca67b619df8f247f3f4c9f40e67bf5ea503ad94/pytest-dependency-0.6.0.tar.gz", hash = "sha256:934b0e6a39d95995062c193f7eaeed8a8ffa06ff1bcef4b62b0dc74a708bacc1", size = 19499, upload-time = "2023-12-31T20:38:54.991Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/ea/84509533e0f6477960b8a9179d240d93c909c6543e4dd8209932026d7815/pytest_dependency-0.6.1.tar.gz", hash = "sha256:246c24d2a5fc743a942cec4408853640e56a05ba58d46e5b213a1d4b738a2464", size = 20837, upload-time = "2026-02-15T18:08:43.927Z" }
 
 [[package]]
 name = "pytest-mock"


### PR DESCRIPTION
## Summary
- `pytest-dependency==0.6.0` (2023) fails to build on Windows with recent setuptools — `copy_file()` no longer accepts the `dry_run` kwarg, breaking the wheel build during `uv sync`.
- 0.6.1 (released 2026-02-15) ships build tool chain fixes that resolve the issue.

This unblocks the Windows leg of the CI matrix, currently red on `main`.

## Test plan
- [x] `uv lock` updates pytest-dependency 0.6.0 → 0.6.1
- [x] `tox run -e 3.14` passes locally
- [ ] CI green on `windows-latest`

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR bumps the minimum version of `pytest-dependency` from 0.6.0 to 0.6.1 to fix a Windows build failure. The newer version resolves compatibility issues with recent setuptools where the `copy_file()` function no longer accepts the `dry_run` keyword argument, which was causing wheel builds to fail during `uv sync` on Windows CI environments.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `pyproject.toml` |
| 2 | `uv.lock` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->