### PR TITLE
chore: prune unused test deps and wire slotscheck + yamlfmt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -15,7 +15,6 @@ template: |
   Special thanks to the following contributors who helped with this release: $CONTRIBUTORS
 
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION
-
 change-template: "- $TITLE by @$AUTHOR in (#$NUMBER)"
 no-changes-template: "- No changes"
 exclude-contributors:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,24 +9,24 @@ jobs:
     runs-on: ubuntu-latest
     name: Publish on PyPI
     permissions:
-      id-token: write # IMPORTANT: Mandatory for Trusted Publishing (gh-action-pypi-publish)
-      contents: write # IMPORTANT: Mandatory for GitHub Release
+      id-token: write  # IMPORTANT: Mandatory for Trusted Publishing (gh-action-pypi-publish)
+      contents: write  # IMPORTANT: Mandatory for GitHub Release
     # Specifying a GitHub environment is optional, but strongly encouraged
     environment:
       name: publish
       url: https://pypi.org/project/micoo/${{ github.ref_name }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version-file: ".python-version"
       - name: Setup uv
         id: setup-uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: |

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -11,11 +11,11 @@ jobs:
       pull-requests: write
     steps:
       - name: Lint PR Title
-        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50  # v6.1.1
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v3.0.4
         # When the previous steps fails, the workflow would stop. By adding this
         # condition you can continue the execution with the populated error message.
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
@@ -33,7 +33,7 @@ jobs:
             ```
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v3.0.4
         with:
           header: pr-title-lint-error
           delete: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version-file: ".python-version"
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: |
@@ -59,14 +59,14 @@ jobs:
         run: |
           env || true
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version-file: ".python-version"
       - name: Setup uv
         id: setup-uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: |
@@ -79,7 +79,7 @@ jobs:
         run: uv run --locked tox run
       - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
         with:
           files: ./coverage.xml
           flags: ${{ matrix.os }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Draft a Release
-        uses: release-drafter/release-drafter@c2e2804cc59f45f57076a99af580d0fedb697927 # v7.3.0
+        uses: release-drafter/release-drafter@c2e2804cc59f45f57076a99af580d0fedb697927  # v7.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,0 +1,5 @@
+line_ending: lf
+formatter:
+  type: basic
+  include_document_start: true
+  pad_line_comments: 2

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
+---
 coverage:
   status:
     project:
@@ -8,16 +9,13 @@ coverage:
       default:
         target: auto
         threshold: 1%
-
 comment:
   layout: "reach, diff, flags, files"
   behavior: default
   require_changes: false
-
 flag_management:
   default_rules:
     carryforward: true
-
 ignore:
   - "tests/**"
   - "src/micoo/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -264,6 +264,7 @@ commands = [
   ],
   [
     "yamlfmt",
+    "-gitignore_excludes",
     "-lint",
     ".",
   ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,15 +82,7 @@ lint = [
   "validate-pyproject[all]==0.25",
   "vulture==2.16",
 ]
-test = [
-  "coverage-enable-subprocess==1.0",
-  "coverage[toml]==7.14.0",
-  "pytest-dependency==0.6.1",
-  "pytest-mock==3.15.1",
-  "pytest-rerunfailures==16.2",
-  "pytest-xdist[psutil]==3.8.0",
-  "pytest==9.0.3",
-]
+test = ["coverage[toml]==7.14.0", "pytest-dependency==0.6.1", "pytest==9.0.3"]
 
 [build-system]
 requires = ["hatch-vcs", "hatchling"]
@@ -221,20 +213,60 @@ wheel_build_env = ".pkg"
 [tool.tox.env.style]
 base_python = ["3.14"]
 commands = [
-  ["ruff", "check"],
-  ["ruff", "format"],
-  ["mypy"],
-  ["pyright"],
-  ["ty", "check"],
-  ["pyrefly", "check"],
-  ["vulture"],
-  # ["slotscheck", "src"],
-  ["taplo", "lint"],
-  ["taplo", "format"],
-  ["validate-pyproject", "pyproject.toml"],
-  ["typos", "--diff"],
-  ["actionlint"],
-  # ["yamlfmt", "."],
+  [
+    "ruff",
+    "check",
+  ],
+  [
+    "ruff",
+    "format",
+  ],
+  [
+    "mypy",
+  ],
+  [
+    "pyright",
+  ],
+  [
+    "ty",
+    "check",
+  ],
+  [
+    "pyrefly",
+    "check",
+  ],
+  [
+    "vulture",
+  ],
+  [
+    "slotscheck",
+    "-m",
+    "micoo",
+  ],
+  [
+    "taplo",
+    "lint",
+  ],
+  [
+    "taplo",
+    "format",
+  ],
+  [
+    "validate-pyproject",
+    "pyproject.toml",
+  ],
+  [
+    "typos",
+    "--diff",
+  ],
+  [
+    "actionlint",
+  ],
+  [
+    "yamlfmt",
+    "-lint",
+    ".",
+  ],
 ]
 runner = "uv-venv-runner"
 dependency_groups = ["lint"]

--- a/uv.lock
+++ b/uv.lock
@@ -138,33 +138,12 @@ wheels = [
 ]
 
 [[package]]
-name = "coverage-enable-subprocess"
-version = "1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "coverage" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/31/f4/57693bcf041ba641501b7a2fafc9d3d2de647355d78c6a2e07fb53648eaa/coverage_enable_subprocess-1.0.tar.gz", hash = "sha256:fdbd3dc9532007cd87ef84f38e16024c5b0ccb4ab2d1755225a7edf937acc011", size = 2695, upload-time = "2016-05-11T18:49:48.048Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/58/d8dd7edbf5e120942b6395b4c034506c68e56f656074522c83b59d9a4991/coverage_enable_subprocess-1.0-py2.py3-none-any.whl", hash = "sha256:27982522339ec77662965e0d859da5662162962c874d54d2250426506818cbdc", size = 4033, upload-time = "2016-05-11T18:48:49.701Z" },
-]
-
-[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
-]
-
-[[package]]
-name = "execnet"
-version = "2.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bb/ff/b4c0dc78fbe20c3e59c0c7334de0c27eb4001a2b2017999af398bf730817/execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3", size = 166524, upload-time = "2024-04-08T09:04:19.245Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/09/2aea36ff60d16dd8879bdb2f5b3ee0ba8d08cbbdcdfe870e695ce3784385/execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc", size = 40612, upload-time = "2024-04-08T09:04:17.414Z" },
 ]
 
 [[package]]
@@ -305,7 +284,6 @@ dependencies = [
 dev = [
     { name = "actionlint-py" },
     { name = "coverage" },
-    { name = "coverage-enable-subprocess" },
     { name = "google-yamlfmt" },
     { name = "mypy" },
     { name = "prek" },
@@ -313,9 +291,6 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-dependency" },
-    { name = "pytest-mock" },
-    { name = "pytest-rerunfailures" },
-    { name = "pytest-xdist", extra = ["psutil"] },
     { name = "ruff" },
     { name = "slotscheck" },
     { name = "taplo" },
@@ -342,12 +317,8 @@ lint = [
 ]
 test = [
     { name = "coverage" },
-    { name = "coverage-enable-subprocess" },
     { name = "pytest" },
     { name = "pytest-dependency" },
-    { name = "pytest-mock" },
-    { name = "pytest-rerunfailures" },
-    { name = "pytest-xdist", extra = ["psutil"] },
 ]
 
 [package.metadata]
@@ -362,7 +333,6 @@ requires-dist = [
 dev = [
     { name = "actionlint-py", specifier = "==1.7.12.24" },
     { name = "coverage", extras = ["toml"], specifier = "==7.14.0" },
-    { name = "coverage-enable-subprocess", specifier = "==1.0" },
     { name = "google-yamlfmt", specifier = "==0.21.0" },
     { name = "mypy", specifier = "==2.1.0" },
     { name = "prek", specifier = "==0.4.0" },
@@ -370,9 +340,6 @@ dev = [
     { name = "pyright", specifier = "==1.1.409" },
     { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-dependency", specifier = "==0.6.1" },
-    { name = "pytest-mock", specifier = "==3.15.1" },
-    { name = "pytest-rerunfailures", specifier = "==16.2" },
-    { name = "pytest-xdist", extras = ["psutil"], specifier = "==3.8.0" },
     { name = "ruff", specifier = "==0.15.13" },
     { name = "slotscheck", specifier = "==0.19.1" },
     { name = "taplo", specifier = "==0.9.3" },
@@ -399,12 +366,8 @@ lint = [
 ]
 test = [
     { name = "coverage", extras = ["toml"], specifier = "==7.14.0" },
-    { name = "coverage-enable-subprocess", specifier = "==1.0" },
     { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-dependency", specifier = "==0.6.1" },
-    { name = "pytest-mock", specifier = "==3.15.1" },
-    { name = "pytest-rerunfailures", specifier = "==16.2" },
-    { name = "pytest-xdist", extras = ["psutil"], specifier = "==3.8.0" },
 ]
 
 [[package]]
@@ -513,21 +476,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/d2/e0cca68af94b7639badd3967fc37ae6159979baf6cc3c7f1d68f0a966bdf/prek-0.4.0-py3-none-win32.whl", hash = "sha256:ce2a8feb5dc1f1e748879d0e14c2145353059b830ac5e3f64d92127ab16efc78", size = 5204721, upload-time = "2026-05-14T10:50:49.269Z" },
     { url = "https://files.pythonhosted.org/packages/2d/5b/462c907502e7b9f634c73de4e6d36fa44b5d652a52a9ddd51811b2030ca7/prek-0.4.0-py3-none-win_amd64.whl", hash = "sha256:b218d92ad5d2ff0b59240d7d837fa9edc61849894958acb3a225efff7a2faa65", size = 5595119, upload-time = "2026-05-14T10:50:47.482Z" },
     { url = "https://files.pythonhosted.org/packages/0d/a0/a0be2f73cbc8fd65a5e1de576aa5a5324339c7cc9f7dd328009a5e1a3ae1/prek-0.4.0-py3-none-win_arm64.whl", hash = "sha256:ff1f1fa311023418d40a443bca6928a9f5ce073d0b9130b641954183aa31736d", size = 5423774, upload-time = "2026-05-14T10:50:44.19Z" },
-]
-
-[[package]]
-name = "psutil"
-version = "7.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2a/80/336820c1ad9286a4ded7e845b2eccfcb27851ab8ac6abece774a6ff4d3de/psutil-7.0.0.tar.gz", hash = "sha256:7be9c3eba38beccb6495ea33afd982a44074b78f28c434a1f51cc07fd315c456", size = 497003, upload-time = "2025-02-13T21:54:07.946Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/e6/2d26234410f8b8abdbf891c9da62bee396583f713fb9f3325a4760875d22/psutil-7.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:101d71dc322e3cffd7cea0650b09b3d08b8e7c4109dd6809fe452dfd00e58b25", size = 238051, upload-time = "2025-02-13T21:54:12.36Z" },
-    { url = "https://files.pythonhosted.org/packages/04/8b/30f930733afe425e3cbfc0e1468a30a18942350c1a8816acfade80c005c4/psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:39db632f6bb862eeccf56660871433e111b6ea58f2caea825571951d4b6aa3da", size = 239535, upload-time = "2025-02-13T21:54:16.07Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/ed/d362e84620dd22876b55389248e522338ed1bf134a5edd3b8231d7207f6d/psutil-7.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fcee592b4c6f146991ca55919ea3d1f8926497a713ed7faaf8225e174581e91", size = 275004, upload-time = "2025-02-13T21:54:18.662Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/b9/b0eb3f3cbcb734d930fdf839431606844a825b23eaf9a6ab371edac8162c/psutil-7.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b1388a4f6875d7e2aff5c4ca1cc16c545ed41dd8bb596cefea80111db353a34", size = 277986, upload-time = "2025-02-13T21:54:21.811Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/a2/709e0fe2f093556c17fbafda93ac032257242cabcc7ff3369e2cb76a97aa/psutil-7.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5f098451abc2828f7dc6b58d44b532b22f2088f4999a937557b603ce72b1993", size = 279544, upload-time = "2025-02-13T21:54:24.68Z" },
-    { url = "https://files.pythonhosted.org/packages/50/e6/eecf58810b9d12e6427369784efe814a1eec0f492084ce8eb8f4d89d6d61/psutil-7.0.0-cp37-abi3-win32.whl", hash = "sha256:ba3fcef7523064a6c9da440fc4d6bd07da93ac726b5733c29027d7dc95b39d99", size = 241053, upload-time = "2025-02-13T21:54:34.31Z" },
-    { url = "https://files.pythonhosted.org/packages/50/1b/6921afe68c74868b4c9fa424dad3be35b095e16687989ebbb50ce4fceb7c/psutil-7.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:4cf3d4eb1aa9b348dec30105c55cd9b7d4629285735a102beb4441e38db90553", size = 244885, upload-time = "2025-02-13T21:54:37.486Z" },
 ]
 
 [[package]]
@@ -674,49 +622,6 @@ dependencies = [
     { name = "setuptools" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/ea/84509533e0f6477960b8a9179d240d93c909c6543e4dd8209932026d7815/pytest_dependency-0.6.1.tar.gz", hash = "sha256:246c24d2a5fc743a942cec4408853640e56a05ba58d46e5b213a1d4b738a2464", size = 20837, upload-time = "2026-02-15T18:08:43.927Z" }
-
-[[package]]
-name = "pytest-mock"
-version = "3.15.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
-]
-
-[[package]]
-name = "pytest-rerunfailures"
-version = "16.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/27/fd0209642f3a1069da3e0be3c7e339f942d052d81ccb1fb4eb9b187d3633/pytest_rerunfailures-16.2.tar.gz", hash = "sha256:5f5a32f15674a3d54f7598388fcd3cc1bc5c37284731a4704a44485dcdda5e23", size = 32121, upload-time = "2026-05-13T08:13:26.998Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/a5/d8c1ad74529b483044b787ead2d24ecc624bca4084a509002102e4bab8cc/pytest_rerunfailures-16.2-py3-none-any.whl", hash = "sha256:c22a53d2827becc76f057d4ded123c0e726523f2f0e5f0bb4efb31fd59e1f14e", size = 14505, upload-time = "2026-05-13T08:13:25.485Z" },
-]
-
-[[package]]
-name = "pytest-xdist"
-version = "3.8.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "execnet" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
-]
-
-[package.optional-dependencies]
-psutil = [
-    { name = "psutil" },
-]
 
 [[package]]
 name = "python-discovery"


### PR DESCRIPTION
## Summary
- Drop `pytest-mock`, `pytest-rerunfailures`, `pytest-xdist[psutil]`, and `coverage-enable-subprocess` from the test dependency group — none referenced in tests, config, or tox commands.
- Wire `slotscheck -m micoo` and `yamlfmt -lint .` into the tox `style` env so every lint dep is exercised.
- Apply `yamlfmt` formatting across `.github/**` and `codecov.yml` to satisfy the new lint step.

## Test plan
- [ ] `uv run --locked tox run -e style` passes locally
- [ ] CI green on this branch

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR removes unused test dependencies (`pytest-mock`, `pytest-rerunfailures`, `pytest-xdist[psutil]`, and `coverage-enable-subprocess`) from the project, enables `slotscheck -m micoo` and `yamlfmt -lint .` linting commands in the tox style environment, and applies `yamlfmt` formatting to YAML files in `.github/` and `codecov.yml` to satisfy the new linting requirements.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `pyproject.toml` |
| 2 | `uv.lock` |
| 3 | `tox.ini` |
| 4 | `.github/workflows/ci.yml` |
| 5 | `.github/workflows/cd.yml` |
| 6 | `.github/workflows/check-pr-title.yml` |
| 7 | `.github/workflows/release-drafter.yml` |
| 8 | `.github/release-drafter.yml` |
| 9 | `codecov.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->