### PR TITLE
fix: restore click dependency and shrink update() try clause

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
+  "click>=8.1.7",
   "gitpython>=3.1.46",
   "platformdirs>=4.9.6",
   "pydantic-settings>=2.14.1",

--- a/src/micoo/main.py
+++ b/src/micoo/main.py
@@ -97,6 +97,26 @@ def prepare_cookbook(name: str) -> str:
     )
 
 
+def clone_or_pull_repository() -> str:
+    """Clone the `mise-cookbooks` repository, or pull it if it already exists.
+
+    Returns:
+        A message describing whether the repository was cloned or pulled.
+    """
+    if not repository_path.exists():
+        logger.info("Repository does not exist. Cloning...")
+        Repo.clone_from(
+            url=cookbooks_repository_url,
+            to_path=repository_path,
+            branch="main",
+        )
+        return "Repository cloned successfully."
+    logger.info("Repository exists. Pulling...")
+    repo = Repo(repository_path)
+    repo.remotes[0].pull()
+    return "Repository pulled successfully."
+
+
 @app.command()
 def update() -> None:
     """Clone or fetch the `mise-cookbooks` repository.
@@ -108,31 +128,17 @@ def update() -> None:
         Repository pulled successfully.
     """
     logger.info("Command `update` called.")
-    repo: Repo | None = None
     try:
-        if not repository_path.exists():
-            logger.info("Repository does not exist. Cloning...")
-            repo = Repo.clone_from(
-                url=cookbooks_repository_url,
-                to_path=repository_path,
-                branch="main",
-            )
-            msg = "Repository cloned successfully."
-            typer.echo(msg)
-            logger.info(msg)
-            return
-        logger.info("Repository exists. Pulling...")
-        repo = Repo(repository_path)
-        repo.remotes[0].pull()
-        msg = "Repository pulled successfully."
-        typer.echo(msg)
-        logger.info(msg)
+        msg = clone_or_pull_repository()
     except GitCommandError as e:
         logger.error(f"Git command error: {e}")
         typer.echo("An error occurred while cloning/pulling the repository.")
     except Exception as e:  # noqa: BLE001
         logger.error(f"An unexpected error occurred: {e}")
         typer.echo("An error occurred while cloning/pulling the repository.")
+    else:
+        typer.echo(msg)
+        logger.info(msg)
 
 
 @app.command(name="list")

--- a/uv.lock
+++ b/uv.lock
@@ -274,6 +274,7 @@ wheels = [
 name = "micoo"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "gitpython" },
     { name = "platformdirs" },
     { name = "pydantic-settings" },
@@ -323,6 +324,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.1.7" },
     { name = "gitpython", specifier = ">=3.1.46" },
     { name = "platformdirs", specifier = ">=4.9.6" },
     { name = "pydantic-settings", specifier = ">=2.14.1" },


### PR DESCRIPTION
## Summary

Fixes two pre-existing CI failures that affect `main` and every branch (surfaced by Renovate #149, but not caused by it).

### 1. Tests fail: `ModuleNotFoundError: No module named 'click'`
typer **0.26.7** dropped `click` from its dependencies (now only `shellingham`, `rich`, `annotated-doc`, `colorama`). `src/micoo/main.py` imports `click` directly for `click.Choice` but only declared `typer`, so it relied on a transitive dep that vanished. The tox test env resolves typer unconstrained (it's a runtime dep, not in the test/dev groups), pulls 0.26.7, and collection fails. A fresh `uvx`/`pipx install micoo` would hit the same.

**Fix:** declare `click>=8.1.7` as a direct dependency + relock.

### 2. Ruff fails: `too-many-statements-in-try-clause` (12 > 5)
ruff 0.15.18 enforces this under `ALL` + preview. `update()`'s `try` held 12 statements.

**Fix:** extract `clone_or_pull_repository()`; the `try` now holds one statement and the success echo/log moved to an `else` block (also satisfies `TRY300`, and is safer — only code that can raise `GitCommandError` stays in `try`). Dropped the unused `repo` local.

## Verification
- `uv run --locked tox run -e style` — all linters/type-checkers pass (ruff, mypy, pyright, ty, pyrefly, vulture, slotscheck, taplo, typos, actionlint, yamlfmt)
- `uv run --locked tox run -e 3.14` — 31 passed

## Summary by Sourcery

Declare the missing CLI dependency and refactor the repository update command to satisfy new linting constraints while preserving behavior.

Bug Fixes:
- Add click as a direct runtime dependency to prevent import errors when running the CLI.

Enhancements:
- Extract repository clone/pull logic into a dedicated helper used by the update command, simplifying control flow and aligning with linting rules.